### PR TITLE
add sockaddr_in support, fix helper socklen sockaddr bug

### DIFF
--- a/builder.py
+++ b/builder.py
@@ -85,12 +85,6 @@ ffi.cdef('''
 
 # sockaddr_in and helper
 ffi.cdef('''
-    int printf(const char *format, ...);
-    const char *inet_ntop(int af, const void *src,
-                             char *dst, socklen_t size);
-    uint16_t ntohs(uint16_t netshort);
-    void bzero(void *s, size_t n);
-
     typedef uint32_t in_addr_t;
     typedef unsigned short int sa_family_t;
     typedef uint16_t in_port_t;
@@ -102,8 +96,20 @@ ffi.cdef('''
          struct in_addr sin_addr;
          ...;
     };
-    extern int inet_aton (const char *__cp, struct in_addr *__inp);
-    extern __u16 htons(uint16_t hostshort);
+    struct in6_addr {
+        union {
+            uint8_t __u6_addr8[16];
+            uint16_t __u6__addr16[8];
+            uint32_t __u6_addr32[4];
+        } __in6_u;
+    };
+    struct sockaddr_in6 {
+        sa_family_t sin6_family;
+        in_port_t sin6_port;
+        uint32_t sin6_flowinfo;
+        struct in6_addr sin6_addr;
+        uint32_t sin6_scope_id;
+    };
 ''')
 
 

--- a/builder.py
+++ b/builder.py
@@ -14,6 +14,11 @@ ffi.set_source('liburing._liburing',
                '''
                    #include <fcntl.h>       /* statx(2) - Definition of AT_* constants */
                    #include "liburing.h"
+                   #include <netinet/in.h>
+                   #include <arpa/inet.h>
+                   #include <stdlib.h>
+                   #include <strings.h>
+
                ''',
                sources=['./libs/liburing/src/queue.c',
                         './libs/liburing/src/register.c',
@@ -70,6 +75,31 @@ ffi.cdef('''
         uint64_t    mode;
         uint64_t    resolve;
     };
+
+''')
+
+
+# sockaddr_in and helper
+ffi.cdef('''
+    int printf(const char *format, ...);
+    const char *inet_ntop(int af, const void *src,
+                             char *dst, socklen_t size);
+    uint16_t ntohs(uint16_t netshort);
+    void bzero(void *s, size_t n);
+
+    typedef uint32_t in_addr_t;
+    typedef unsigned short int sa_family_t;
+    typedef uint16_t in_port_t;
+
+    struct  in_addr { in_addr_t s_addr; };
+    struct sockaddr_in {
+         sa_family_t sin_family;
+         in_port_t sin_port;
+         struct in_addr sin_addr;
+         ...;
+    };
+    extern int inet_aton (const char *__cp, struct in_addr *__inp);
+    extern __u16 htons(uint16_t hostshort);
 ''')
 
 

--- a/liburing/helper.py
+++ b/liburing/helper.py
@@ -1,7 +1,7 @@
 from ._liburing import ffi, lib
 
 __all__ = ('NULL', 'files', 'io_uring', 'io_uring_cqe', 'io_uring_cqes', 'iovec', 'timespec',
-           'sigmask', 'sockaddr')
+           'sigmask', 'sockaddr', 'build_sockaddr_in', 'sockaddr_in')
 
 
 NULL = ffi.NULL
@@ -146,5 +146,22 @@ def sockaddr():
             >>> sock_addr, sock_len = sockaddr()
     '''
     addr = ffi.new('struct sockaddr *')
-    len_ = ffi.new('socklen_t *', ffi.sizeof(addr))
-    return addr, len_
+    return addr, ffi.new('socklen_t *', ffi.sizeof('struct sockaddr'))
+
+
+def sockaddr_in():
+    sa = ffi.new('struct sockaddr_in *')
+    len_ = ffi.sizeof('struct sockaddr_in')
+    lib.bzero(sa, len_)
+    return sa, ffi.new('socklen_t *', len_)
+
+
+def build_sockaddr_in(ip, port):
+    if isinstance(ip, str):
+        ip = ip.encode('utf8')
+    sa = ffi.new('struct sockaddr_in *')
+    len_ = ffi.sizeof('struct sockaddr_in')
+    lib.bzero(sa, len_)
+    lib.inet_aton(ip, ffi.addressof(sa.sin_addr))
+    sa.sin_port = lib.htons(port)
+    return sa, ffi.new('socklen_t *', len_)

--- a/test/connect_test.py
+++ b/test/connect_test.py
@@ -1,0 +1,81 @@
+from socket import socket, AF_INET, SOCK_STREAM, \
+        SOL_SOCKET, SO_REUSEADDR, SO_REUSEPORT, SO_ERROR
+
+import liburing
+from liburing import ffi
+
+
+def connect_socket(ring):
+    conn_sock = socket(AF_INET, SOCK_STREAM, 0)
+    with conn_sock:
+        conn_sock.setsockopt(SOL_SOCKET, SO_REUSEPORT, 1)
+        conn_sock.setsockopt(SOL_SOCKET, SO_REUSEADDR, 1)
+
+        sa, sock_len = liburing.build_sockaddr_in("127.0.0.1", 12315)
+        sa.sin_family = AF_INET
+        # DEBUG print sockaddr_in
+        # buffer = liburing.ffi.new('char []', 1024)
+        # liburing.inet_ntop(
+        #     AF_INET,
+        #     liburing.ffi.addressof(sa.sin_addr),
+        #     buffer,
+        #     len(buffer)
+        # )
+        # liburing.printf(b'address: %s\n', buffer)
+        # print("port: ", liburing.ntohs(sa.sin_port))
+
+        sqe = liburing.io_uring_get_sqe(ring)
+        liburing.io_uring_prep_connect(
+            sqe,
+            conn_sock.fileno(),
+            ffi.cast('struct sockaddr *', sa),
+            sock_len[0]
+        )
+        sqe.user_data = 1
+        res = submit_and_wait(ring)
+        return res
+
+
+def submit_and_wait(ring):
+    assert liburing.io_uring_submit_and_wait(ring, 1) == 1, \
+        "io_uring_submit() failed"
+    cqes = liburing.io_uring_cqes()
+    assert liburing.io_uring_peek_cqe(ring, cqes) == 0, \
+        "io_uring_peek_cqe() failed."
+    cqe = cqes[0]
+    liburing.io_uring_cqe_seen(ring, cqe)
+    # DEBUG print cqe info
+    # print("user_data: ", cqe.user_data)
+    # print("res: ", cqe.res)
+    # print("flags: ", cqe.flags)
+    return cqe.res
+
+
+def test_connect_with_no_peer(ring):
+    assert connect_socket(ring) == -111, "connect_socket() failed."
+    return 0
+
+
+def test_connect(ring):
+    listen_sock = socket(AF_INET, SOCK_STREAM, 0)
+    listen_sock.bind(('127.0.0.1', 12315))
+    listen_sock.listen(5)
+    with listen_sock:
+        assert connect_socket(ring) == 0,\
+            "connect_socket() failed"
+        return 0
+
+
+def main():
+    ring = liburing.io_uring()
+    assert liburing.io_uring_queue_init(32, ring, 0) == 0,\
+        "io_uring_queue_setup() failed"
+    assert test_connect_with_no_peer(ring) == 0,\
+        "test_connect_with_no_peer() failed"
+    assert test_connect(ring) == 0,\
+        "test_connect() failed"
+    liburing.io_uring_queue_exit(ring)
+    return 0
+
+
+main()

--- a/test/connect_test.py
+++ b/test/connect_test.py
@@ -64,7 +64,7 @@ def test_connect(ring, ipv6=False):
         return 0
 
 
-def main():
+def test_main():
     ring = liburing.io_uring()
     assert liburing.io_uring_queue_init(32, ring, 0) == 0,\
         "io_uring_queue_setup() failed"
@@ -78,6 +78,3 @@ def main():
         "test_connect() failed, ipv6: True"
     liburing.io_uring_queue_exit(ring)
     return 0
-
-
-main()


### PR DESCRIPTION
1. helper function

- add support functions: liburing.build_sockaddr_in, liburing.sockaddr_in, you can use with io_uring_prep_connect, test with test/connect_test.py

2. bug fix

- liburing.sockaddr return value socklen initial with ffi.sizeof(addr) which is the size of addr pointer rather struct sockaddr.